### PR TITLE
Scheduling

### DIFF
--- a/project/scheduling/AcyclicGraph.agda
+++ b/project/scheduling/AcyclicGraph.agda
@@ -46,13 +46,37 @@ module _ where
   _ : n0 ≡ Pair.second (list-head-guaranteed ll {s≤s z≤n})
   _ = refl
 
-
 successors : {E N : Set} → AcyclicGraphNode E N → List (AcyclicGraphNode E N)
 successors n = map Pair.second (AcyclicGraphNode.edges n)
 
 -- This version doesn't pass the termination checker :(
 -- descendants : {E N : Set} → AcyclicGraphNode E N → List (AcyclicGraphNode E N)
 -- descendants n = concat (map descendants (successors n)) ++ (successors n)
+
+open import Data.List.Membership.DecPropositional hiding (_∈_)
+open import Relation.Binary
+open import Relation.Nullary
+
+list-remove-duplicates : {A : Set} → List A → Decidable {A = A} _≡_ → List A
+list-remove-duplicates l deq = remove-duplicates-impl [] l deq
+  where
+  remove-duplicates-impl : {A : Set} → List A → List A → Decidable {A = A} _≡_ → List A
+  remove-duplicates-impl l [] deq = l
+  remove-duplicates-impl l (x ∷ xs) deq with (_∈?_ deq) x l
+  ...                                      | yes p = remove-duplicates-impl l xs deq
+  ...                                      | no ¬p = remove-duplicates-impl (x ∷ l) xs deq
+
+open import Data.List.Relation.Unary.AllPairs
+--allpairs-dec : {A : Set} → (l : List A) → (deq : Decidable {A = A} _≢_) → AllPairs deq l
+
+{-
+list-contains-duplicates : {A : Set} → (l : List A) → (deq : Decidable {A = A} _≢_) → AllPairs deq l
+list-contains-duplicates l = {!!}
+-}
+{-
+_ : {A : Set} (deq : Decidable {A = A} _≡_) → Relation.Nullary.Decidable.True ((_∈?_ deq) 1 (1 ∷ []))
+_ = {!!}
+-}
 
 descendants : {E N : Set} → AcyclicGraphNode E N → List (AcyclicGraphNode E N)
 descendants n[ _ , [] ]n = []

--- a/project/scheduling/AcyclicGraph.agda
+++ b/project/scheduling/AcyclicGraph.agda
@@ -4,12 +4,65 @@ open import Data.Nat
 open import Data.Fin using (Fin ; fromℕ)
 open import Relation.Binary.PropositionalEquality
 open ≡-Reasoning
-open import Data.Bool using (Bool ; true ; false ; if_then_else_ ; _∨_ ; _∧_)
-open import Relation.Nullary.Decidable using (⌊_⌋)
+open import Relation.Nullary
+open import Relation.Nullary.Decidable
 open import Data.List using (List ; [] ; _∷_ ; map ; all ; any ; and ; or; _++_ )
 open import Data.Maybe using (Maybe ; nothing ; just)
 open import Data.List using (List; concat; map; length)
 open import Data.List.Membership.Propositional
+open import Relation.Nullary.Decidable using (True)
+open import Relation.Nullary.Negation
+open import Level
+
+open import Relation.Binary
+open import Data.Empty
+
+open import Data.List.Properties using (≡-dec)
+
+record Dummy : Set where
+  inductive
+  field
+    d : List Dummy
+
+{-
+=-dec-dum : Decidable {A = Dummy} _≡_
+=-dec-dum record { d = d₁ } record { d = d } with ≡-dec =-dec-dum d₁ d
+...                                             | yes p = {!!}
+-}
+
+list-append-eq : {A : Set} → (a0 a1 : A) → (l0 l1 : List A) → a0 ≡ a1 → l0 ≡ l1 → a0 ∷ l0 ≡ a1 ∷ l1
+list-append-eq {A} a0 a1 l0 l1 x x₁ = begin
+                                        a0 ∷ l0 ≡⟨ cong (_∷_ a0) x₁ ⟩
+                                        a0 ∷ l1 ≡⟨ cong (λ z → z ∷ l1) x ⟩ a1 ∷ l1 ∎
+
+dummy-append-eq : (a0 a1 : Dummy) → (l0 l1 : List Dummy) → a0 ≡ a1 → l0 ≡ l1 → record { d = (a0 ∷ l0) } ≡ record { d = (a1 ∷ l1) }
+dummy-append-eq a0 a1 l0 l1 x x₁ = begin
+                                     record { d = a0 ∷ l0 } ≡⟨ cong (λ z → record { d = a0 ∷ z }) x₁ ⟩
+                                     record { d = a0 ∷ l1 } ≡⟨ cong (λ z → record { d = z ∷ l1 }) x ⟩
+                                     record { d = a1 ∷ l1 } ∎
+
+dummy-list-eq : {a0 a1 : Dummy} → a0 ≡ a1 → Dummy.d a0 ≡ Dummy.d a1
+dummy-list-eq  = cong Dummy.d
+
+dummy-lem : (a0 a1 : Dummy) → (l0 l1 : List Dummy) → a0 ≡ a1 → record { d = l0 } ≡ record { d = l1 } → record { d = (a0 ∷ l0) } ≡ record { d = (a1 ∷ l1) }
+dummy-lem a0 a1 l0 l1 x x₁ with dummy-list-eq x₁
+... | p = dummy-append-eq a0 a1 l0 l1 x p
+
+=-dec-dum : Decidable {A = Dummy} _≡_
+=-dec-dum record { d = [] } record { d = [] } = yes refl
+=-dec-dum record { d = (x ∷ d₁) } record { d = [] } = no (λ ())
+=-dec-dum record { d = [] } record { d = (x ∷ d) } = no (λ ())
+=-dec-dum record { d = (x₁ ∷ d₁) } record { d = (x ∷ d) } with =-dec-dum record { d = d₁ } record { d = d }
+...                                                          | no ¬p = no lem
+  where
+  lem : (x : record { d = x₁ ∷ d₁ } ≡ record { d = x ∷ d }) → ⊥
+  lem refl = ¬p refl
+...                                                          | yes p with =-dec-dum x₁ x
+... | no ¬q = no lem
+  where
+  lem : (x : record { d = x₁ ∷ d₁ } ≡ record { d = x ∷ d }) → ⊥
+  lem refl = ¬q refl
+... | yes q = yes (dummy-lem x₁ x d₁ d q p)
 
 record Pair (A B : Set) : Set where
   constructor _,_
@@ -23,6 +76,97 @@ record AcyclicGraphNode (E N : Set) : Set where
   field
     value : N
     edges : List (Pair E (AcyclicGraphNode E N))
+
+_≟Pair_ : {A B : Set} → {_≟A_ : Decidable {A = A} _≡_} → {_≟B_ : Decidable {A = B} _≡_} → Decidable {A = Pair A B} _≡_
+_≟Pair_ {_≟A_ = _≟A_} {_≟B_} (fl , sl) (fr , sr) with fl ≟A fr | sl ≟B sr
+...                                           | yes p | yes q = yes
+                                                                  (begin
+                                                                   (fl , sl) ≡⟨ cong (_,_ fl) q ⟩
+                                                                   (fl , sr) ≡⟨ cong (λ z → z , sr) p ⟩ (fr , sr) ∎)
+...                                           | no ¬p | yes q = no lem
+  where
+  lem : (x : (fl , sl) ≡ (fr , sr)) → ⊥
+  lem refl = ¬p refl
+...                                           | no ¬p | no ¬q = no lem
+  where
+  lem : (x : (fl , sl) ≡ (fr , sr)) → ⊥
+  lem refl = ¬q refl
+...                                           | yes p | no ¬q = no lem
+  where
+  lem : (x : (fl , sl) ≡ (fr , sr)) → Data.Empty.⊥
+  lem refl = ¬q refl
+
+{-
+_≟AGN_ : {E N : Set} → {_≟E_ : Decidable {A = E} _≡_} → {_≟N_ : Decidable {A = N} _≡_} → Decidable {A = AcyclicGraphNode E N} _≡_
+_≟AGN_ {_≟E_ = _≟E_} {_≟N_} n[ value , edges ]n n[ value₁ , edges₁ ]n with value ≟N value₁
+...                                                                      | no ¬p = no lem
+  where
+  lem : (x : n[ value , edges ]n ≡ n[ value₁ , edges₁ ]n) → ⊥
+  lem refl = ¬p refl
+...                                                                      | yes p with (≡-dec (_≟Pair_ {_≟A_ = _≟E_} {_≟B_ = _≟AGN_})) edges edges₁
+...                                                                                 | no ¬q = no lem
+  where
+  lem : (x : n[ value , edges ]n ≡ n[ value₁ , edges₁ ]n) → ⊥
+  lem refl = ¬q refl
+...                                                                                 | yes q = yes
+                                                                                                (begin
+                                                                                                 n[ value , edges ]n ≡⟨ cong (n[_,_]n value) q ⟩
+                                                                                                 n[ value , edges₁ ]n ≡⟨ cong (λ z → n[ z , edges₁ ]n) p ⟩
+                                                                                                 n[ value₁ , edges₁ ]n ∎)
+                                                                                                 -}
+_≟AGN_ : {E N : Set} → {_≟E_ : Decidable {A = E} _≡_} → {_≟N_ : Decidable {A = N} _≡_} → Decidable {A = AcyclicGraphNode E N} _≡_
+_≟AGN_ {_≟E_ = _≟E_} {_≟N_} n[ value , [] ]n n[ value₁ , [] ]n with value ≟N value₁
+...                                                               | no ¬p = no lem
+  where
+  lem : (x : n[ value , [] ]n ≡ n[ value₁ , [] ]n) → ⊥
+  lem refl = ¬p refl
+...                                                               | yes p = yes (cong (λ z → n[ z , [] ]n) p)
+_≟AGN_ {_≟E_ = _≟E_} {_≟N_} n[ value , [] ]n n[ value₁ , x ∷ edges₁ ]n = no λ ()
+_≟AGN_ {_≟E_ = _≟E_} {_≟N_} n[ value , x ∷ edges ]n n[ value₁ , [] ]n = no λ ()
+_≟AGN_ {_≟E_ = _≟E_} {_≟N_} n[ value , x ∷ edges ]n n[ value₁ , x₁ ∷ edges₁ ]n with value ≟N value₁
+...                                                                               | no ¬p = no lem
+  where
+  lem : (x : n[ value , x ∷ edges ]n ≡ n[ value₁ , x₁ ∷ edges₁ ]n) → ⊥
+  lem refl = ¬p refl
+...                                                                               | yes p with _≟AGN_ {_≟E_ = _≟E_} {_≟N_ = _≟N_} n[ value , edges ]n n[ value₁ , edges₁ ]n
+...                                                                                          | no ¬q = no lem
+  where
+  lem : (x : n[ value , x ∷ edges ]n ≡ n[ value₁ , x₁ ∷ edges₁ ]n) → ⊥
+  lem refl = ¬q refl
+_≟AGN_ {_≟E_ = _≟E_} {_≟N_} n[ value , (first , second) ∷ edges ]n n[ value₁ , (first₁ , second₁) ∷ edges₁ ]n | yes p | yes q with first ≟E first₁
+...                                                                                                                              | no ¬z = no lem
+  where
+  lem : (x
+           : n[ value , (first , second) ∷ edges ]n ≡
+             n[ value₁ , (first₁ , second₁) ∷ edges₁ ]n) →
+          ⊥
+  lem refl = ¬z refl
+...                                                                                                                              | yes z with _≟AGN_  {_≟E_ = _≟E_} {_≟N_} second second₁
+...                                                                                                                                         | no ¬w = no lem
+  where
+  lem : (x
+           : n[ value , (first , second) ∷ edges ]n ≡
+             n[ value₁ , (first₁ , second₁) ∷ edges₁ ]n) →
+          ⊥
+  lem refl = ¬w refl
+...                                                                                                                                         | yes w = yes (agn-append p z w (agn-eq-to-list-eq q))
+  where
+  pair-append : {A B : Set} {a0 a1 : A} {b0 b1 : B} → a0 ≡ a1 → b0 ≡ b1 → a0 , b0 ≡ a1 , b1
+  pair-append {A} {B} {a0} {a1} {b0} {b1} x x₁ = begin
+                       (a0 , b0) ≡⟨ cong (_,_ a0) x₁ ⟩
+                       (a0 , b1) ≡⟨ cong (λ z → z , b1) x ⟩ (a1 , b1) ∎
+  list-append : {A : Set} {a0 a1 : A} {l0 l1 : List A} → a0 ≡ a1 → l0 ≡ l1 → a0 ∷ l0 ≡ a1 ∷ l1
+  list-append {A} {a0} {a1} {l0} {l1} x x₁ = begin
+                       a0 ∷ l0 ≡⟨ cong (_∷_ a0) x₁ ⟩
+                       a0 ∷ l1 ≡⟨ cong (λ z → z ∷ l1) x ⟩ a1 ∷ l1 ∎
+  agn-append-helper :  {E N : Set} {n0 n1 : N} {l0 l1 : List (Pair E (AcyclicGraphNode E N))} → n0 ≡ n1 → l0 ≡ l1 → n[ n0 , l0 ]n ≡ n[ n1 , l1 ]n
+  agn-append-helper {E} {N} {n0} {n1} {l0} {l1} x x₁ = begin
+                                                         n[ n0 , l0 ]n ≡⟨ cong (n[_,_]n n0) x₁ ⟩
+                                                         n[ n0 , l1 ]n ≡⟨ cong (λ z → n[ z , l1 ]n) x ⟩ n[ n1 , l1 ]n ∎
+  agn-eq-to-list-eq : {E N : Set} {n0 n1 : N} {l0 l1 : List (Pair E (AcyclicGraphNode E N))} → n[ n0 , l0 ]n ≡ n[ n1 , l1 ]n → l0 ≡ l1
+  agn-eq-to-list-eq refl = refl
+  agn-append : {E N : Set} {n0 n1 : N} {e0 e1 : E} {s0 s1 : AcyclicGraphNode E N} {l0 l1 : List (Pair E (AcyclicGraphNode E N))} → n0 ≡ n1 → e0 ≡ e1 → s0 ≡ s1 → l0 ≡ l1 → n[ n0 , (e0 , s0) ∷ l0 ]n ≡ n[ n1 , (e1 , s1) ∷ l1 ]n
+  agn-append x x₁ x₂ x₃ = agn-append-helper x (list-append (pair-append x₁ x₂)  x₃)
 
 record AcyclicGraph (E N : Set) : Set where
   constructor g[_]g
@@ -46,8 +190,9 @@ module _ where
   _ : n0 ≡ Pair.second (list-head-guaranteed ll {s≤s z≤n})
   _ = refl
 
+
 successors : {E N : Set} → AcyclicGraphNode E N → List (AcyclicGraphNode E N)
-successors n = map Pair.second (AcyclicGraphNode.edges n)
+successors n = Data.List.map Pair.second (AcyclicGraphNode.edges n)
 
 -- This version doesn't pass the termination checker :(
 -- descendants : {E N : Set} → AcyclicGraphNode E N → List (AcyclicGraphNode E N)
@@ -66,8 +211,6 @@ list-remove-duplicates l deq = remove-duplicates-impl [] l deq
   ...                                      | yes p = remove-duplicates-impl l xs deq
   ...                                      | no ¬p = remove-duplicates-impl (x ∷ l) xs deq
 
-open import Data.List.Relation.Unary.AllPairs
---allpairs-dec : {A : Set} → (l : List A) → (deq : Decidable {A = A} _≢_) → AllPairs deq l
 
 {-
 list-contains-duplicates : {A : Set} → (l : List A) → (deq : Decidable {A = A} _≢_) → AllPairs deq l
@@ -82,13 +225,27 @@ descendants : {E N : Set} → AcyclicGraphNode E N → List (AcyclicGraphNode E 
 descendants n[ _ , [] ]n = []
 descendants n[ value , (_ , child) ∷ edges ]n = descendants child ++ (child ∷ descendants n[ value , edges ]n)
 
-data _↝_ : {E N : Set} → AcyclicGraphNode E N → AcyclicGraphNode E N → Set where
-  depends-on : {E N : Set} → {parent : AcyclicGraphNode E N} → {child :  AcyclicGraphNode E N} → (proof : child ∈ (descendants parent)) → parent ↝ child
+all-nodes : {E N : Set} → {_≟E_ : Decidable {A = E} _≡_} → {_≟N_ : Decidable {A = N} _≡_} → AcyclicGraph E N → List (AcyclicGraphNode E N)
+all-nodes {_≟E_ = _≟E_} {_≟N_ = _≟N_} g[ head ]g = list-remove-duplicates (descendants head) (_≟AGN_ {_≟E_ = _≟E_} {_≟N_ = _≟N_})
 
-module _ where
-  open import Data.List.Relation.Unary.Any using (Any)
-
-  _ : n1 ↝ n0
-  _ = depends-on (Any.here refl)
+data _↝_ : {E N : Set} → Rel (AcyclicGraphNode E N) 0ℓ where
+  depends-on : {E N : Set} → (_≟E_ : Decidable {A = E} _≡_) → (_≟N_ : Decidable {A = N} _≡_) → {parent : AcyclicGraphNode E N} → {child :  AcyclicGraphNode E N} → {proof : True ((_∈?_ (_≟AGN_ {_≟E_ = _≟E_} {_≟N_ = _≟N_})) child (descendants parent))} → parent ↝ child
 
 
+_ : n1 ↝ n0
+_ = depends-on Data.Nat._≟_ Data.Nat._≟_
+
+--_ : n0 ↝ n1 -- Doesn't compile!
+--_ = depends-on Data.Nat._≟_ Data.Nat._≟_
+
+↝⇒p : {E N : Set} {p c : AcyclicGraphNode E N} → p ↝ c → c ∈ (descendants p)
+↝⇒p (depends-on _≟E_ _≟N_ {proof = p}) = toWitness p
+
+
+_↝?_ : {E N : Set} → (_≟E_ : Decidable {A = E} _≡_) → (_≟N_ : Decidable {A = N} _≡_) → Decidable {A = AcyclicGraphNode E N} _↝_
+(_≟E_ ↝? _≟N_) parent child with (_∈?_ (_≟AGN_ {_≟E_ = _≟E_} {_≟N_ = _≟N_})) child (descendants parent)
+...                            | yes p = yes (depends-on _≟E_ _≟N_ {proof = fromWitness p})
+...                            | no ¬p = no lem
+  where
+  lem : (x : parent ↝ child) → ⊥
+  lem (depends-on _≟E_ _≟N_ {proof = p}) = contradiction (toWitness p)  ¬p

--- a/project/scheduling/AcyclicGraph.agda
+++ b/project/scheduling/AcyclicGraph.agda
@@ -77,6 +77,9 @@ record AcyclicGraphNode (E N : Set) : Set where
     value : N
     edges : List (Pair E (AcyclicGraphNode E N))
 
+get-val : {E N : Set} → AcyclicGraphNode E N → N
+get-val x = AcyclicGraphNode.value x
+
 _≟Pair_ : {A B : Set} → {_≟A_ : Decidable {A = A} _≡_} → {_≟B_ : Decidable {A = B} _≡_} → Decidable {A = Pair A B} _≡_
 _≟Pair_ {_≟A_ = _≟A_} {_≟B_} (fl , sl) (fr , sr) with fl ≟A fr | sl ≟B sr
 ...                                           | yes p | yes q = yes
@@ -226,7 +229,7 @@ descendants n[ _ , [] ]n = []
 descendants n[ value , (_ , child) ∷ edges ]n = descendants child ++ (child ∷ descendants n[ value , edges ]n)
 
 all-nodes : {E N : Set} → {_≟E_ : Decidable {A = E} _≡_} → {_≟N_ : Decidable {A = N} _≡_} → AcyclicGraph E N → List (AcyclicGraphNode E N)
-all-nodes {_≟E_ = _≟E_} {_≟N_ = _≟N_} g[ head ]g = list-remove-duplicates (descendants head) (_≟AGN_ {_≟E_ = _≟E_} {_≟N_ = _≟N_})
+all-nodes {_≟E_ = _≟E_} {_≟N_ = _≟N_} g[ head ]g = list-remove-duplicates (head ∷ descendants head) (_≟AGN_ {_≟E_ = _≟E_} {_≟N_ = _≟N_})
 
 data _↝_ : {E N : Set} → Rel (AcyclicGraphNode E N) 0ℓ where
   depends-on : {E N : Set} → (_≟E_ : Decidable {A = E} _≡_) → (_≟N_ : Decidable {A = N} _≡_) → {parent : AcyclicGraphNode E N} → {child :  AcyclicGraphNode E N} → {proof : True ((_∈?_ (_≟AGN_ {_≟E_ = _≟E_} {_≟N_ = _≟N_})) child (descendants parent))} → parent ↝ child

--- a/project/scheduling/AcyclicGraph.agda
+++ b/project/scheduling/AcyclicGraph.agda
@@ -1,6 +1,6 @@
 module AcyclicGraph where
 
-open import Data.Nat
+open import Data.Nat using (ℕ; _<_; _≤_)
 open import Data.Fin using (Fin ; fromℕ)
 open import Relation.Binary.PropositionalEquality
 open ≡-Reasoning
@@ -16,8 +16,11 @@ open import Level
 open import Pair
 open import Relation.Binary
 open import Data.Empty
+open import DecidableEquality
 
-record AcyclicGraphNode (E N : Set) : Set where
+open DecEq {{...}}
+
+record AcyclicGraphNode (E N : Set)  : Set where
   inductive
   constructor n[_,_]n
   field
@@ -27,77 +30,84 @@ record AcyclicGraphNode (E N : Set) : Set where
 get-val : {E N : Set} → AcyclicGraphNode E N → N
 get-val x = AcyclicGraphNode.value x
 
-{-
-_≟AGN_ : {E N : Set} → {_≟E_ : Decidable {A = E} _≡_} → {_≟N_ : Decidable {A = N} _≡_} → Decidable {A = AcyclicGraphNode E N} _≡_
-_≟AGN_ {_≟E_ = _≟E_} {_≟N_} n[ value , edges ]n n[ value₁ , edges₁ ]n with value ≟N value₁
-...                                                                      | no ¬p = no lem
-  where
-  lem : (x : n[ value , edges ]n ≡ n[ value₁ , edges₁ ]n) → ⊥
-  lem refl = ¬p refl
-...                                                                      | yes p with (≡-dec (_≟Pair_ {_≟A_ = _≟E_} {_≟B_ = _≟AGN_})) edges edges₁
-...                                                                                 | no ¬q = no lem
-  where
-  lem : (x : n[ value , edges ]n ≡ n[ value₁ , edges₁ ]n) → ⊥
-  lem refl = ¬q refl
-...                                                                                 | yes q = yes
-                                                                                                (begin
-                                                                                                 n[ value , edges ]n ≡⟨ cong (n[_,_]n value) q ⟩
-                                                                                                 n[ value , edges₁ ]n ≡⟨ cong (λ z → n[ z , edges₁ ]n) p ⟩
-                                                                                                 n[ value₁ , edges₁ ]n ∎)
-                                                                                                 -}
-_≟AGN_ : {E N : Set} → {_≟E_ : Decidable {A = E} _≡_} → {_≟N_ : Decidable {A = N} _≡_} → Decidable {A = AcyclicGraphNode E N} _≡_
-_≟AGN_ {_≟E_ = _≟E_} {_≟N_} n[ value , [] ]n n[ value₁ , [] ]n with value ≟N value₁
-...                                                               | no ¬p = no lem
-  where
-  lem : (x : n[ value , [] ]n ≡ n[ value₁ , [] ]n) → ⊥
-  lem refl = ¬p refl
-...                                                               | yes p = yes (cong (λ z → n[ z , [] ]n) p)
-_≟AGN_ {_≟E_ = _≟E_} {_≟N_} n[ value , [] ]n n[ value₁ , x ∷ edges₁ ]n = no λ ()
-_≟AGN_ {_≟E_ = _≟E_} {_≟N_} n[ value , x ∷ edges ]n n[ value₁ , [] ]n = no λ ()
-_≟AGN_ {_≟E_ = _≟E_} {_≟N_} n[ value , x ∷ edges ]n n[ value₁ , x₁ ∷ edges₁ ]n with value ≟N value₁
-...                                                                               | no ¬p = no lem
-  where
-  lem : (x : n[ value , x ∷ edges ]n ≡ n[ value₁ , x₁ ∷ edges₁ ]n) → ⊥
-  lem refl = ¬p refl
-...                                                                               | yes p with _≟AGN_ {_≟E_ = _≟E_} {_≟N_ = _≟N_} n[ value , edges ]n n[ value₁ , edges₁ ]n
-...                                                                                          | no ¬q = no lem
-  where
-  lem : (x : n[ value , x ∷ edges ]n ≡ n[ value₁ , x₁ ∷ edges₁ ]n) → ⊥
-  lem refl = ¬q refl
-_≟AGN_ {_≟E_ = _≟E_} {_≟N_} n[ value , (first , second) ∷ edges ]n n[ value₁ , (first₁ , second₁) ∷ edges₁ ]n | yes p | yes q with first ≟E first₁
-...                                                                                                                              | no ¬z = no lem
-  where
-  lem : (x
-           : n[ value , (first , second) ∷ edges ]n ≡
-             n[ value₁ , (first₁ , second₁) ∷ edges₁ ]n) →
-          ⊥
-  lem refl = ¬z refl
-...                                                                                                                              | yes z with _≟AGN_  {_≟E_ = _≟E_} {_≟N_} second second₁
-...                                                                                                                                         | no ¬w = no lem
-  where
-  lem : (x
-           : n[ value , (first , second) ∷ edges ]n ≡
-             n[ value₁ , (first₁ , second₁) ∷ edges₁ ]n) →
-          ⊥
-  lem refl = ¬w refl
-...                                                                                                                                         | yes w = yes (agn-append p z w (agn-eq-to-list-eq q))
-  where
-  pair-append : {A B : Set} {a0 a1 : A} {b0 b1 : B} → a0 ≡ a1 → b0 ≡ b1 → a0 , b0 ≡ a1 , b1
-  pair-append {A} {B} {a0} {a1} {b0} {b1} x x₁ = begin
-                       (a0 , b0) ≡⟨ cong (_,_ a0) x₁ ⟩
-                       (a0 , b1) ≡⟨ cong (λ z → z , b1) x ⟩ (a1 , b1) ∎
-  list-append : {A : Set} {a0 a1 : A} {l0 l1 : List A} → a0 ≡ a1 → l0 ≡ l1 → a0 ∷ l0 ≡ a1 ∷ l1
-  list-append {A} {a0} {a1} {l0} {l1} x x₁ = begin
-                       a0 ∷ l0 ≡⟨ cong (_∷_ a0) x₁ ⟩
-                       a0 ∷ l1 ≡⟨ cong (λ z → z ∷ l1) x ⟩ a1 ∷ l1 ∎
-  agn-append-helper :  {E N : Set} {n0 n1 : N} {l0 l1 : List (Pair E (AcyclicGraphNode E N))} → n0 ≡ n1 → l0 ≡ l1 → n[ n0 , l0 ]n ≡ n[ n1 , l1 ]n
-  agn-append-helper {E} {N} {n0} {n1} {l0} {l1} x x₁ = begin
-                                                         n[ n0 , l0 ]n ≡⟨ cong (n[_,_]n n0) x₁ ⟩
-                                                         n[ n0 , l1 ]n ≡⟨ cong (λ z → n[ z , l1 ]n) x ⟩ n[ n1 , l1 ]n ∎
-  agn-eq-to-list-eq : {E N : Set} {n0 n1 : N} {l0 l1 : List (Pair E (AcyclicGraphNode E N))} → n[ n0 , l0 ]n ≡ n[ n1 , l1 ]n → l0 ≡ l1
-  agn-eq-to-list-eq refl = refl
-  agn-append : {E N : Set} {n0 n1 : N} {e0 e1 : E} {s0 s1 : AcyclicGraphNode E N} {l0 l1 : List (Pair E (AcyclicGraphNode E N))} → n0 ≡ n1 → e0 ≡ e1 → s0 ≡ s1 → l0 ≡ l1 → n[ n0 , (e0 , s0) ∷ l0 ]n ≡ n[ n1 , (e1 , s1) ∷ l1 ]n
-  agn-append x x₁ x₂ x₃ = agn-append-helper x (list-append (pair-append x₁ x₂)  x₃)
+module _ where
+  -- Side project: how do we clean this up? Simpler implementation doesn't pass the termination checker.
+  {-
+  _≟AGN_ : {E N : Set} → {_≟E_ : Decidable {A = E} _≡_} → {_≟N_ : Decidable {A = N} _≡_} → Decidable {A = AcyclicGraphNode E N} _≡_
+  _≟AGN_ {_≟E_ = _≟E_} {_≟N_} n[ value , edges ]n n[ value₁ , edges₁ ]n with value ≟N value₁
+  ...                                                                      | no ¬p = no lem
+    where
+    lem : (x : n[ value , edges ]n ≡ n[ value₁ , edges₁ ]n) → ⊥
+    lem refl = ¬p refl
+  ...                                                                      | yes p with (≡-dec (_≟Pair_ {_≟A_ = _≟E_} {_≟B_ = _≟AGN_})) edges edges₁
+  ...                                                                                 | no ¬q = no lem
+    where
+    lem : (x : n[ value , edges ]n ≡ n[ value₁ , edges₁ ]n) → ⊥
+    lem refl = ¬q refl
+  ...                                                                                 | yes q = yes
+                                                                                                  (begin
+                                                                                                   n[ value , edges ]n ≡⟨ cong (n[_,_]n value) q ⟩
+                                                                                                   n[ value , edges₁ ]n ≡⟨ cong (λ z → n[ z , edges₁ ]n) p ⟩
+                                                                                                   n[ value₁ , edges₁ ]n ∎)
+  -}
+  -- TODO: Implement this in terms of DecEq.
+  _≟AGN_ : {E N : Set} → {_≟E_ : Decidable {A = E} _≡_} → {_≟N_ : Decidable {A = N} _≡_} → Decidable {A = AcyclicGraphNode E N} _≡_
+  _≟AGN_ {_≟E_ = _≟E_} {_≟N_} n[ value , [] ]n n[ value₁ , [] ]n with value ≟N value₁
+  ...                                                               | no ¬p = no lem
+    where
+    lem : (x : n[ value , [] ]n ≡ n[ value₁ , [] ]n) → ⊥
+    lem refl = ¬p refl
+  ...                                                               | yes p = yes (cong (λ z → n[ z , [] ]n) p)
+  _≟AGN_ {_≟E_ = _≟E_} {_≟N_} n[ value , [] ]n n[ value₁ , x ∷ edges₁ ]n = no λ ()
+  _≟AGN_ {_≟E_ = _≟E_} {_≟N_} n[ value , x ∷ edges ]n n[ value₁ , [] ]n = no λ ()
+  _≟AGN_ {_≟E_ = _≟E_} {_≟N_} n[ value , x ∷ edges ]n n[ value₁ , x₁ ∷ edges₁ ]n with value ≟N value₁
+  ...                                                                               | no ¬p = no lem
+    where
+    lem : (x : n[ value , x ∷ edges ]n ≡ n[ value₁ , x₁ ∷ edges₁ ]n) → ⊥
+    lem refl = ¬p refl
+  ...                                                                               | yes p with _≟AGN_ {_≟E_ = _≟E_} {_≟N_ = _≟N_} n[ value , edges ]n n[ value₁ , edges₁ ]n
+  ...                                                                                          | no ¬q = no lem
+    where
+    lem : (x : n[ value , x ∷ edges ]n ≡ n[ value₁ , x₁ ∷ edges₁ ]n) → ⊥
+    lem refl = ¬q refl
+  _≟AGN_ {_≟E_ = _≟E_} {_≟N_} n[ value , (first , second) ∷ edges ]n n[ value₁ , (first₁ , second₁) ∷ edges₁ ]n | yes p | yes q with first ≟E first₁
+  ...                                                                                                                              | no ¬z = no lem
+    where
+    lem : (x
+             : n[ value , (first , second) ∷ edges ]n ≡
+               n[ value₁ , (first₁ , second₁) ∷ edges₁ ]n) →
+            ⊥
+    lem refl = ¬z refl
+  ...                                                                                                                              | yes z with _≟AGN_  {_≟E_ = _≟E_} {_≟N_} second second₁
+  ...                                                                                                                                         | no ¬w = no lem
+    where
+    lem : (x
+             : n[ value , (first , second) ∷ edges ]n ≡
+               n[ value₁ , (first₁ , second₁) ∷ edges₁ ]n) →
+            ⊥
+    lem refl = ¬w refl
+  ...                                                                                                                                         | yes w = yes (agn-append p z w (agn-eq-to-list-eq q))
+    where
+    pair-append : {A B : Set} {a0 a1 : A} {b0 b1 : B} → a0 ≡ a1 → b0 ≡ b1 → a0 , b0 ≡ a1 , b1
+    pair-append {A} {B} {a0} {a1} {b0} {b1} x x₁ = begin
+                         (a0 , b0) ≡⟨ cong (_,_ a0) x₁ ⟩
+                         (a0 , b1) ≡⟨ cong (λ z → z , b1) x ⟩ (a1 , b1) ∎
+    list-append : {A : Set} {a0 a1 : A} {l0 l1 : List A} → a0 ≡ a1 → l0 ≡ l1 → a0 ∷ l0 ≡ a1 ∷ l1
+    list-append {A} {a0} {a1} {l0} {l1} x x₁ = begin
+                         a0 ∷ l0 ≡⟨ cong (_∷_ a0) x₁ ⟩
+                         a0 ∷ l1 ≡⟨ cong (λ z → z ∷ l1) x ⟩ a1 ∷ l1 ∎
+    agn-append-helper :  {E N : Set} {n0 n1 : N} {l0 l1 : List (Pair E (AcyclicGraphNode E N))} → n0 ≡ n1 → l0 ≡ l1 → n[ n0 , l0 ]n ≡ n[ n1 , l1 ]n
+    agn-append-helper {E} {N} {n0} {n1} {l0} {l1} x x₁ = begin
+                                                           n[ n0 , l0 ]n ≡⟨ cong (n[_,_]n n0) x₁ ⟩
+                                                           n[ n0 , l1 ]n ≡⟨ cong (λ z → n[ z , l1 ]n) x ⟩ n[ n1 , l1 ]n ∎
+    agn-eq-to-list-eq : {E N : Set} {n0 n1 : N} {l0 l1 : List (Pair E (AcyclicGraphNode E N))} → n[ n0 , l0 ]n ≡ n[ n1 , l1 ]n → l0 ≡ l1
+    agn-eq-to-list-eq refl = refl
+    agn-append : {E N : Set} {n0 n1 : N} {e0 e1 : E} {s0 s1 : AcyclicGraphNode E N} {l0 l1 : List (Pair E (AcyclicGraphNode E N))} → n0 ≡ n1 → e0 ≡ e1 → s0 ≡ s1 → l0 ≡ l1 → n[ n0 , (e0 , s0) ∷ l0 ]n ≡ n[ n1 , (e1 , s1) ∷ l1 ]n
+    agn-append x x₁ x₂ x₃ = agn-append-helper x (list-append (pair-append x₁ x₂)  x₃)
+
+instance
+  DecEqAGN : {E N : Set} {{DecEqE : DecEq E}} {{DecEqN : DecEq N}} → DecEq (AcyclicGraphNode E N)
+  DecEq._≟_ DecEqAGN = _≟AGN_ {_≟E_ = _≟_} {_≟N_ = _≟_}
 
 record AcyclicGraph (E N : Set) : Set where
   constructor g[_]g
@@ -116,11 +126,6 @@ module _ where
   list-head-guaranteed : {A : Set} → (l : List A) → {p : 1 ≤ (Data.List.length l)} → A
   list-head-guaranteed (x ∷ xs) = x
 
-  -- Equality.
-  ll = AcyclicGraphNode.edges n1
-  _ : n0 ≡ Pair.second (list-head-guaranteed ll {s≤s z≤n})
-  _ = refl
-
 
 successors : {E N : Set} → AcyclicGraphNode E N → List (AcyclicGraphNode E N)
 successors n = Data.List.map Pair.second (AcyclicGraphNode.edges n)
@@ -133,50 +138,42 @@ open import Data.List.Membership.DecPropositional hiding (_∈_)
 open import Relation.Binary
 open import Relation.Nullary
 
-list-remove-duplicates : {A : Set} → List A → Decidable {A = A} _≡_ → List A
-list-remove-duplicates l deq = remove-duplicates-impl [] l deq
+-- TODO: Ideally this should also return Allpairs _≢_ for the given list as proof.
+list-remove-duplicates : {A : Set} → {{DecEqA : DecEq A}} → List A → List A
+list-remove-duplicates l = remove-duplicates-impl [] l
   where
-  remove-duplicates-impl : {A : Set} → List A → List A → Decidable {A = A} _≡_ → List A
-  remove-duplicates-impl l [] deq = l
-  remove-duplicates-impl l (x ∷ xs) deq with (_∈?_ deq) x l
-  ...                                      | yes p = remove-duplicates-impl l xs deq
-  ...                                      | no ¬p = remove-duplicates-impl (x ∷ l) xs deq
+  remove-duplicates-impl : {A : Set} → {{DecEqA : DecEq A}} → List A → List A → List A
+  remove-duplicates-impl l [] = l
+  remove-duplicates-impl {{DecEqA = DecEqA}} l (x ∷ xs) with (_∈?_ _≟_) x l
+  ...                                      | yes p = remove-duplicates-impl l xs
+  ...                                      | no ¬p = remove-duplicates-impl (x ∷ l) xs
 
-
-{-
-list-contains-duplicates : {A : Set} → (l : List A) → (deq : Decidable {A = A} _≢_) → AllPairs deq l
-list-contains-duplicates l = {!!}
--}
-{-
-_ : {A : Set} (deq : Decidable {A = A} _≡_) → Relation.Nullary.Decidable.True ((_∈?_ deq) 1 (1 ∷ []))
-_ = {!!}
--}
 
 descendants : {E N : Set} → AcyclicGraphNode E N → List (AcyclicGraphNode E N)
 descendants n[ _ , [] ]n = []
 descendants n[ value , (_ , child) ∷ edges ]n = descendants child ++ (child ∷ descendants n[ value , edges ]n)
 
-all-nodes : {E N : Set} → {_≟E_ : Decidable {A = E} _≡_} → {_≟N_ : Decidable {A = N} _≡_} → AcyclicGraph E N → List (AcyclicGraphNode E N)
-all-nodes {_≟E_ = _≟E_} {_≟N_ = _≟N_} g[ head ]g = list-remove-duplicates (head ∷ descendants head) (_≟AGN_ {_≟E_ = _≟E_} {_≟N_ = _≟N_})
+all-nodes : {E N : Set} {{DecEqE : DecEq E}} {{DecEqN : DecEq N}} → AcyclicGraph E N → List (AcyclicGraphNode E N)
+all-nodes g[ head ]g = list-remove-duplicates (head ∷ descendants head)
 
 data _↝_ : {E N : Set} → Rel (AcyclicGraphNode E N) 0ℓ where
-  depends-on : {E N : Set} → (_≟E_ : Decidable {A = E} _≡_) → (_≟N_ : Decidable {A = N} _≡_) → {parent : AcyclicGraphNode E N} → {child :  AcyclicGraphNode E N} → {proof : True ((_∈?_ (_≟AGN_ {_≟E_ = _≟E_} {_≟N_ = _≟N_})) child (descendants parent))} → parent ↝ child
+  depends-on : {E N : Set} {{DecEqE : DecEq E}} {{DecEqN : DecEq N}} {parent child : AcyclicGraphNode E N} → {proof : True ((_∈?_ _≟_) child (descendants parent))} → parent ↝ child
 
 
 _ : n1 ↝ n0
-_ = depends-on Data.Nat._≟_ Data.Nat._≟_
+_ = depends-on
 
 --_ : n0 ↝ n1 -- Doesn't compile!
 --_ = depends-on Data.Nat._≟_ Data.Nat._≟_
 
 ↝⇒p : {E N : Set} {p c : AcyclicGraphNode E N} → p ↝ c → c ∈ (descendants p)
-↝⇒p (depends-on _≟E_ _≟N_ {proof = p}) = toWitness p
+↝⇒p (depends-on {proof = p}) = toWitness p
 
 
-_↝?_ : {E N : Set} → (_≟E_ : Decidable {A = E} _≡_) → (_≟N_ : Decidable {A = N} _≡_) → Decidable {A = AcyclicGraphNode E N} _↝_
-(_≟E_ ↝? _≟N_) parent child with (_∈?_ (_≟AGN_ {_≟E_ = _≟E_} {_≟N_ = _≟N_})) child (descendants parent)
-...                            | yes p = yes (depends-on _≟E_ _≟N_ {proof = fromWitness p})
+_↝?_ : {E N : Set} {{DecEqE : DecEq E}} {{DecEqN : DecEq N}} → Decidable {A = AcyclicGraphNode E N} _↝_
+parent ↝? child with (_∈?_ _≟_) child (descendants parent)
+...                            | yes p = yes (depends-on {proof = fromWitness p})
 ...                            | no ¬p = no lem
   where
   lem : (x : parent ↝ child) → ⊥
-  lem (depends-on _≟E_ _≟N_ {proof = p}) = contradiction (toWitness p)  ¬p
+  lem (depends-on {proof = p}) = contradiction (toWitness p)  ¬p

--- a/project/scheduling/AcyclicGraph.agda
+++ b/project/scheduling/AcyclicGraph.agda
@@ -13,62 +13,9 @@ open import Data.List.Membership.Propositional
 open import Relation.Nullary.Decidable using (True)
 open import Relation.Nullary.Negation
 open import Level
-
+open import Pair
 open import Relation.Binary
 open import Data.Empty
-
-open import Data.List.Properties using (≡-dec)
-
-record Dummy : Set where
-  inductive
-  field
-    d : List Dummy
-
-{-
-=-dec-dum : Decidable {A = Dummy} _≡_
-=-dec-dum record { d = d₁ } record { d = d } with ≡-dec =-dec-dum d₁ d
-...                                             | yes p = {!!}
--}
-
-list-append-eq : {A : Set} → (a0 a1 : A) → (l0 l1 : List A) → a0 ≡ a1 → l0 ≡ l1 → a0 ∷ l0 ≡ a1 ∷ l1
-list-append-eq {A} a0 a1 l0 l1 x x₁ = begin
-                                        a0 ∷ l0 ≡⟨ cong (_∷_ a0) x₁ ⟩
-                                        a0 ∷ l1 ≡⟨ cong (λ z → z ∷ l1) x ⟩ a1 ∷ l1 ∎
-
-dummy-append-eq : (a0 a1 : Dummy) → (l0 l1 : List Dummy) → a0 ≡ a1 → l0 ≡ l1 → record { d = (a0 ∷ l0) } ≡ record { d = (a1 ∷ l1) }
-dummy-append-eq a0 a1 l0 l1 x x₁ = begin
-                                     record { d = a0 ∷ l0 } ≡⟨ cong (λ z → record { d = a0 ∷ z }) x₁ ⟩
-                                     record { d = a0 ∷ l1 } ≡⟨ cong (λ z → record { d = z ∷ l1 }) x ⟩
-                                     record { d = a1 ∷ l1 } ∎
-
-dummy-list-eq : {a0 a1 : Dummy} → a0 ≡ a1 → Dummy.d a0 ≡ Dummy.d a1
-dummy-list-eq  = cong Dummy.d
-
-dummy-lem : (a0 a1 : Dummy) → (l0 l1 : List Dummy) → a0 ≡ a1 → record { d = l0 } ≡ record { d = l1 } → record { d = (a0 ∷ l0) } ≡ record { d = (a1 ∷ l1) }
-dummy-lem a0 a1 l0 l1 x x₁ with dummy-list-eq x₁
-... | p = dummy-append-eq a0 a1 l0 l1 x p
-
-=-dec-dum : Decidable {A = Dummy} _≡_
-=-dec-dum record { d = [] } record { d = [] } = yes refl
-=-dec-dum record { d = (x ∷ d₁) } record { d = [] } = no (λ ())
-=-dec-dum record { d = [] } record { d = (x ∷ d) } = no (λ ())
-=-dec-dum record { d = (x₁ ∷ d₁) } record { d = (x ∷ d) } with =-dec-dum record { d = d₁ } record { d = d }
-...                                                          | no ¬p = no lem
-  where
-  lem : (x : record { d = x₁ ∷ d₁ } ≡ record { d = x ∷ d }) → ⊥
-  lem refl = ¬p refl
-...                                                          | yes p with =-dec-dum x₁ x
-... | no ¬q = no lem
-  where
-  lem : (x : record { d = x₁ ∷ d₁ } ≡ record { d = x ∷ d }) → ⊥
-  lem refl = ¬q refl
-... | yes q = yes (dummy-lem x₁ x d₁ d q p)
-
-record Pair (A B : Set) : Set where
-  constructor _,_
-  field
-    first : A
-    second : B
 
 record AcyclicGraphNode (E N : Set) : Set where
   inductive
@@ -79,25 +26,6 @@ record AcyclicGraphNode (E N : Set) : Set where
 
 get-val : {E N : Set} → AcyclicGraphNode E N → N
 get-val x = AcyclicGraphNode.value x
-
-_≟Pair_ : {A B : Set} → {_≟A_ : Decidable {A = A} _≡_} → {_≟B_ : Decidable {A = B} _≡_} → Decidable {A = Pair A B} _≡_
-_≟Pair_ {_≟A_ = _≟A_} {_≟B_} (fl , sl) (fr , sr) with fl ≟A fr | sl ≟B sr
-...                                           | yes p | yes q = yes
-                                                                  (begin
-                                                                   (fl , sl) ≡⟨ cong (_,_ fl) q ⟩
-                                                                   (fl , sr) ≡⟨ cong (λ z → z , sr) p ⟩ (fr , sr) ∎)
-...                                           | no ¬p | yes q = no lem
-  where
-  lem : (x : (fl , sl) ≡ (fr , sr)) → ⊥
-  lem refl = ¬p refl
-...                                           | no ¬p | no ¬q = no lem
-  where
-  lem : (x : (fl , sl) ≡ (fr , sr)) → ⊥
-  lem refl = ¬q refl
-...                                           | yes p | no ¬q = no lem
-  where
-  lem : (x : (fl , sl) ≡ (fr , sr)) → Data.Empty.⊥
-  lem refl = ¬q refl
 
 {-
 _≟AGN_ : {E N : Set} → {_≟E_ : Decidable {A = E} _≡_} → {_≟N_ : Decidable {A = N} _≡_} → Decidable {A = AcyclicGraphNode E N} _≡_

--- a/project/scheduling/DecidableEquality.agda
+++ b/project/scheduling/DecidableEquality.agda
@@ -1,0 +1,38 @@
+module DecidableEquality where
+--open import Data.Nat
+--import Data.Nat.Properties
+open import Relation.Binary.PropositionalEquality
+open ≡-Reasoning
+open import Data.Bool using (Bool ; true ; false ; if_then_else_ ; _∨_ ; _∧_)
+open import Data.List using (List ; [] ; _∷_ ; map ; all ; any ; and ; or )
+open import Data.List.Relation.Unary.AllPairs using (AllPairs; allPairs?)
+open import Data.List.Relation.Unary.All using (All)
+open import Data.Maybe using (Maybe ; nothing ; just)
+open import Data.Sum using (_⊎_)
+open import Level using (0ℓ)
+open import Relation.Unary using (Pred)
+open import Relation.Binary
+open import Relation.Nullary
+open import Relation.Nullary.Decidable using (True; False; ⌊_⌋; toWitness; fromWitness)
+open import Relation.Nullary.Negation
+open import Relation.Nullary.Product
+open import Relation.Nullary.Sum
+open import Data.Empty
+open import Data.Product using (_×_)
+open import Interval
+open import AcyclicGraph
+open import Agda.Builtin.Unit
+
+
+_≟⊤_ : Decidable {A = ⊤} _≡_
+tt ≟⊤ tt = yes refl
+
+record DecEq (A : Set) : Set where
+  field
+    _≟_ : Decidable {A = A} _≡_
+
+open DecEq {{...}}
+
+instance
+  DecEq⊤ : DecEq ⊤
+  _≟_ {{DecEq⊤}} = _≟⊤_

--- a/project/scheduling/DecidableEquality.agda
+++ b/project/scheduling/DecidableEquality.agda
@@ -1,5 +1,5 @@
 module DecidableEquality where
---open import Data.Nat
+open import Data.Nat using (ℕ)
 --import Data.Nat.Properties
 open import Relation.Binary.PropositionalEquality
 open ≡-Reasoning
@@ -19,13 +19,7 @@ open import Relation.Nullary.Product
 open import Relation.Nullary.Sum
 open import Data.Empty
 open import Data.Product using (_×_)
-open import Interval
-open import AcyclicGraph
 open import Agda.Builtin.Unit
-
-
-_≟⊤_ : Decidable {A = ⊤} _≡_
-tt ≟⊤ tt = yes refl
 
 record DecEq (A : Set) : Set where
   field
@@ -33,6 +27,26 @@ record DecEq (A : Set) : Set where
 
 open DecEq {{...}}
 
+module _ where
+  _≟⊤_ : Decidable {A = ⊤} _≡_
+  tt ≟⊤ tt = yes refl
+
 instance
   DecEq⊤ : DecEq ⊤
   _≟_ {{DecEq⊤}} = _≟⊤_
+
+  DecEqℕ : DecEq ℕ
+  _≟_ {{DecEqℕ}} = Data.Nat._≟_
+
+--  DecEqBool : DecEq Bool
+--  _≟_ {{DecEqBool}} = Data.Bool._≟_
+
+module _ where
+  test : {A : Set} {{DecEqA : DecEq A}} → A → A → ℕ
+  test a b with a ≟ b
+  ... | yes p = 1
+  ... | no ¬p = 2
+
+  _ = test 4 5
+
+--  _ = test true true

--- a/project/scheduling/Interval.agda
+++ b/project/scheduling/Interval.agda
@@ -75,6 +75,9 @@ _ = strictly-less
 --_ : i₀ << i₁ -- doesn't compile!
 --_ = strictly-less
 
+<<⇒p : {l r : Interval} → l << r → ⌈ l ⌉ < ⌊ r ⌋
+<<⇒p (strictly-less {proof = p}) = toWitness p
+
 _<<?_ : Decidable {A = Interval} _<<_
 l <<? r with (⌈ l ⌉ <? ⌊ r ⌋)
 ...        | yes p = yes (strictly-less {proof = fromWitness p})
@@ -86,8 +89,8 @@ l <<? r with (⌈ l ⌉ <? ⌊ r ⌋)
 data _∈_ : REL ℕ Interval 0ℓ where
   contains : {n : ℕ} → {i : Interval} → {proof : True ((n ≤? ⌈ i ⌉) ×-dec (⌊ i ⌋ ≤? n))} → n ∈ i
 
-∈⇒∈p : {n : ℕ} {i : Interval} → n ∈ i → (n ≤ ⌈ i ⌉) × (⌊ i ⌋ ≤ n)
-∈⇒∈p (contains {proof = proof}) = toWitness proof
+∈⇒p : {n : ℕ} {i : Interval} → n ∈ i → (n ≤ ⌈ i ⌉) × (⌊ i ⌋ ≤ n)
+∈⇒p (contains {proof = proof}) = toWitness proof
 
 _ : 3 ∈ i₀
 _ = contains
@@ -115,6 +118,9 @@ _ = intersects
 --¬∩? : Decidable _∩_
 --¬∩? l r = ¬ ( l ∩ r )
 
+∩⇒p : {l r : Interval} → l ∩ r → (⌊ l ⌋ ∈ r) ⊎ (⌈ l ⌉ ∈ r) ⊎ (⌊ r ⌋ ∈ l)
+∩⇒p (intersects {proof = p}) = toWitness p
+
 _∩?_ : Decidable _∩_
 _∩?_ l r with ((⌊ l ⌋ ∈? r) ⊎-dec (⌈ l ⌉ ∈? r) ⊎-dec (⌊ r ⌋ ∈? l))
 ...         | yes p = yes (intersects {l} {r} {fromWitness p})
@@ -133,17 +139,6 @@ module _ where
 
   neg-trans : {A B : Set} → (B → A) → ¬ A → ¬ B
   neg-trans {A} {B} B→A ¬A = λ z → ¬A (B→A z)
-
-
-data AllIntersect : Pred (List Interval) 0ℓ where
-  all-intersect : {l : List Interval} →  {proof : True (allPairs? _∩?_ l)} → AllIntersect l
-
-
-_ : AllIntersect (i₀ ∷ i₁ ∷ i₃ ∷ [])
-_ = all-intersect
-
---_ : AllIntersect (i₀ ∷ i₁ ∷ i₃ ∷ i₂ ∷ []) -- Doesn't compile!
---_ = all-intersect
 
 
 module _ where

--- a/project/scheduling/Interval.agda
+++ b/project/scheduling/Interval.agda
@@ -18,6 +18,7 @@ open import Relation.Nullary.Sum
 open import Relation.Nullary.Product
 open import Data.Empty
 open import Data.Product
+open import DecidableEquality
 
 record Interval : Set where
   constructor [_▹_]
@@ -34,25 +35,30 @@ record Interval : Set where
 ⌊_⌋ : Interval → ℕ
 ⌊_⌋ i = Interval.lower i
 
-_≟Interval_ : Decidable {A = Interval} _≡_
-[ lower ▹ size ] ≟Interval [ lower₁ ▹ size₁ ] with lower ≟ lower₁ | size ≟ size₁
-...                                              | yes p          | yes q = yes
-                                                                              (begin
-                                                                               [ lower ▹ size ] ≡⟨ cong ([_▹_] lower) q ⟩
-                                                                               [ lower ▹ size₁ ] ≡⟨ cong (λ z → [ z ▹ size₁ ]) p ⟩
-                                                                               [ lower₁ ▹ size₁ ] ∎)
-...                                              | no ¬p          | yes q = no lem
-  where
-  lem : (x : [ lower ▹ size ] ≡ [ lower₁ ▹ size₁ ]) → ⊥
-  lem refl = ¬p refl
-...                                              | yes p          | no ¬q = no lem
-  where
-  lem : (x : [ lower ▹ size ] ≡ [ lower₁ ▹ size₁ ]) → ⊥
-  lem refl = ¬q refl
-...                                              | no ¬p          | no ¬q = no lem
-  where
-  lem : (x : [ lower ▹ size ] ≡ [ lower₁ ▹ size₁ ]) → ⊥
-  lem refl = ¬q refl
+module _ where
+  _≟Interval_ : Decidable {A = Interval} _≡_
+  [ lower ▹ size ] ≟Interval [ lower₁ ▹ size₁ ] with lower ≟ lower₁ | size ≟ size₁
+  ...                                              | yes p          | yes q = yes
+                                                                                (begin
+                                                                                 [ lower ▹ size ] ≡⟨ cong ([_▹_] lower) q ⟩
+                                                                                 [ lower ▹ size₁ ] ≡⟨ cong (λ z → [ z ▹ size₁ ]) p ⟩
+                                                                                 [ lower₁ ▹ size₁ ] ∎)
+  ...                                              | no ¬p          | yes q = no lem
+    where
+    lem : (x : [ lower ▹ size ] ≡ [ lower₁ ▹ size₁ ]) → ⊥
+    lem refl = ¬p refl
+  ...                                              | yes p          | no ¬q = no lem
+    where
+    lem : (x : [ lower ▹ size ] ≡ [ lower₁ ▹ size₁ ]) → ⊥
+    lem refl = ¬q refl
+  ...                                              | no ¬p          | no ¬q = no lem
+    where
+    lem : (x : [ lower ▹ size ] ≡ [ lower₁ ▹ size₁ ]) → ⊥
+    lem refl = ¬q refl
+
+instance
+  DecEqInterval : DecEq Interval
+  DecEq._≟_ DecEqInterval = _≟Interval_
 
 module _ where
   i₀ = [ 2 ▹ 4 ]

--- a/project/scheduling/Pair.agda
+++ b/project/scheduling/Pair.agda
@@ -1,0 +1,43 @@
+module Pair where
+
+open import Data.Nat
+open import Data.Fin using (Fin ; fromℕ)
+open import Relation.Binary.PropositionalEquality
+open ≡-Reasoning
+open import Relation.Nullary
+open import Relation.Nullary.Decidable
+open import Data.List using (List ; [] ; _∷_ ; map ; all ; any ; and ; or; _++_ )
+open import Data.Maybe using (Maybe ; nothing ; just)
+open import Data.List using (List; concat; map; length)
+open import Data.List.Membership.Propositional
+open import Relation.Nullary.Decidable using (True)
+open import Relation.Nullary.Negation
+open import Level
+
+open import Relation.Binary
+open import Data.Empty
+
+record Pair (A B : Set) : Set where
+  constructor _,_
+  field
+    first : A
+    second : B
+
+_≟Pair_ : {A B : Set} → {_≟A_ : Decidable {A = A} _≡_} → {_≟B_ : Decidable {A = B} _≡_} → Decidable {A = Pair A B} _≡_
+_≟Pair_ {_≟A_ = _≟A_} {_≟B_} (fl , sl) (fr , sr) with fl ≟A fr | sl ≟B sr
+...                                           | yes p | yes q = yes
+                                                                  (begin
+                                                                   (fl , sl) ≡⟨ cong (_,_ fl) q ⟩
+                                                                   (fl , sr) ≡⟨ cong (λ z → z , sr) p ⟩ (fr , sr) ∎)
+...                                           | no ¬p | yes q = no lem
+  where
+  lem : (x : (fl , sl) ≡ (fr , sr)) → ⊥
+  lem refl = ¬p refl
+...                                           | no ¬p | no ¬q = no lem
+  where
+  lem : (x : (fl , sl) ≡ (fr , sr)) → ⊥
+  lem refl = ¬q refl
+...                                           | yes p | no ¬q = no lem
+  where
+  lem : (x : (fl , sl) ≡ (fr , sr)) → Data.Empty.⊥
+  lem refl = ¬q refl

--- a/project/scheduling/Pair.agda
+++ b/project/scheduling/Pair.agda
@@ -1,6 +1,5 @@
 module Pair where
 
-open import Data.Nat
 open import Data.Fin using (Fin ; fromℕ)
 open import Relation.Binary.PropositionalEquality
 open ≡-Reasoning
@@ -13,6 +12,9 @@ open import Data.List.Membership.Propositional
 open import Relation.Nullary.Decidable using (True)
 open import Relation.Nullary.Negation
 open import Level
+open import DecidableEquality
+
+open DecEq {{...}}
 
 open import Relation.Binary
 open import Data.Empty
@@ -23,21 +25,27 @@ record Pair (A B : Set) : Set where
     first : A
     second : B
 
-_≟Pair_ : {A B : Set} → {_≟A_ : Decidable {A = A} _≡_} → {_≟B_ : Decidable {A = B} _≡_} → Decidable {A = Pair A B} _≡_
-_≟Pair_ {_≟A_ = _≟A_} {_≟B_} (fl , sl) (fr , sr) with fl ≟A fr | sl ≟B sr
-...                                           | yes p | yes q = yes
-                                                                  (begin
-                                                                   (fl , sl) ≡⟨ cong (_,_ fl) q ⟩
-                                                                   (fl , sr) ≡⟨ cong (λ z → z , sr) p ⟩ (fr , sr) ∎)
-...                                           | no ¬p | yes q = no lem
-  where
-  lem : (x : (fl , sl) ≡ (fr , sr)) → ⊥
-  lem refl = ¬p refl
-...                                           | no ¬p | no ¬q = no lem
-  where
-  lem : (x : (fl , sl) ≡ (fr , sr)) → ⊥
-  lem refl = ¬q refl
-...                                           | yes p | no ¬q = no lem
-  where
-  lem : (x : (fl , sl) ≡ (fr , sr)) → Data.Empty.⊥
-  lem refl = ¬q refl
+module _ where
+  -- TODO: implement this using DecEq
+  _≟Pair_ : {A B : Set} → {_≟A_ : Decidable {A = A} _≡_} → {_≟B_ : Decidable {A = B} _≡_} → Decidable {A = Pair A B} _≡_
+  _≟Pair_ {_≟A_ = _≟A_} {_≟B_} (fl , sl) (fr , sr) with fl ≟A fr | sl ≟B sr
+  ...                                           | yes p | yes q = yes
+                                                                    (begin
+                                                                     (fl , sl) ≡⟨ cong (_,_ fl) q ⟩
+                                                                     (fl , sr) ≡⟨ cong (λ z → z , sr) p ⟩ (fr , sr) ∎)
+  ...                                           | no ¬p | yes q = no lem
+    where
+    lem : (x : (fl , sl) ≡ (fr , sr)) → ⊥
+    lem refl = ¬p refl
+  ...                                           | no ¬p | no ¬q = no lem
+    where
+    lem : (x : (fl , sl) ≡ (fr , sr)) → ⊥
+    lem refl = ¬q refl
+  ...                                           | yes p | no ¬q = no lem
+    where
+    lem : (x : (fl , sl) ≡ (fr , sr)) → Data.Empty.⊥
+    lem refl = ¬q refl
+
+instance
+  DecEqPair : {A B : Set} {{DecEqA : DecEq A}} {{DecEqB : DecEq B}} → DecEq (Pair A B)
+  DecEq._≟_ DecEqPair = _≟Pair_ {_≟A_ = _≟_} {_≟B_ = _≟_}

--- a/project/scheduling/Schedule.agda
+++ b/project/scheduling/Schedule.agda
@@ -1,0 +1,34 @@
+module Schedule where
+open import Data.Nat
+import Data.Nat.Properties
+open import Relation.Binary.PropositionalEquality
+open ≡-Reasoning
+open import Data.Bool using (Bool ; true ; false ; if_then_else_ ; _∨_ ; _∧_)
+open import Data.List using (List ; [] ; _∷_ ; map ; all ; any ; and ; or )
+open import Data.List.Relation.Unary.AllPairs
+open import Data.List.Relation.Unary.All
+open import Data.Maybe using (Maybe ; nothing ; just)
+open import Data.Sum
+open import Level using (0ℓ)
+open import Relation.Unary using (Pred)
+open import Relation.Binary
+open import Relation.Nullary
+open import Relation.Nullary.Decidable using (True; False; ⌊_⌋; toWitness)
+open import Relation.Nullary.Negation
+open import Data.Empty
+open import Data.Product
+open import Interval
+open import AcyclicGraph
+open import Agda.Builtin.Unit
+
+
+Runnable = AcyclicGraphNode ⊤ Interval
+
+_≟⊤_ : Decidable {A = ⊤} _≡_
+tt ≟⊤ tt = yes refl
+
+
+record Schedule : Set where
+  field
+    schedule : AcyclicGraph ⊤ Interval
+    {no-interval-intersection} : True (NoneIntersect? (Data.List.map AcyclicGraphNode.value (all-nodes {_≟E_ = _≟⊤_} {_≟N_ = _≟Interval_} schedule)))

--- a/project/scheduling/Schedule.agda
+++ b/project/scheduling/Schedule.agda
@@ -5,18 +5,20 @@ open import Relation.Binary.PropositionalEquality
 open ≡-Reasoning
 open import Data.Bool using (Bool ; true ; false ; if_then_else_ ; _∨_ ; _∧_)
 open import Data.List using (List ; [] ; _∷_ ; map ; all ; any ; and ; or )
-open import Data.List.Relation.Unary.AllPairs
-open import Data.List.Relation.Unary.All
+open import Data.List.Relation.Unary.AllPairs using (AllPairs; allPairs?)
+open import Data.List.Relation.Unary.All using (All)
 open import Data.Maybe using (Maybe ; nothing ; just)
-open import Data.Sum
+open import Data.Sum using (_⊎_)
 open import Level using (0ℓ)
 open import Relation.Unary using (Pred)
 open import Relation.Binary
 open import Relation.Nullary
-open import Relation.Nullary.Decidable using (True; False; ⌊_⌋; toWitness)
+open import Relation.Nullary.Decidable using (True; False; ⌊_⌋; toWitness; fromWitness)
 open import Relation.Nullary.Negation
+open import Relation.Nullary.Product
+open import Relation.Nullary.Sum
 open import Data.Empty
-open import Data.Product
+open import Data.Product using (_×_)
 open import Interval
 open import AcyclicGraph
 open import Agda.Builtin.Unit
@@ -27,8 +29,63 @@ Runnable = AcyclicGraphNode ⊤ Interval
 _≟⊤_ : Decidable {A = ⊤} _≡_
 tt ≟⊤ tt = yes refl
 
+data _↝⇒<<_ : Rel Runnable 0ℓ where
+  dependency-implies-ordering : {l r : Runnable} → {proof : True (((_↝?_ _≟⊤_ _≟Interval_ l r ) ×-dec (get-val l <<? get-val r)) ⊎-dec ¬? (_↝?_ _≟⊤_ _≟Interval_ l r ))} → l ↝⇒<< r
+
+↝⇒<<⇒p : {l r : Runnable} → l ↝⇒<< r → ((l ↝ r) × (get-val l << get-val r) ⊎ (¬ l ↝ r))
+↝⇒<<⇒p (dependency-implies-ordering {proof = p}) = toWitness p
+
+_↝⇒<<?_ : Decidable {A = Runnable} _↝⇒<<_
+l ↝⇒<<? r with  ((_↝?_ _≟⊤_ _≟Interval_ l r ) ×-dec (get-val l <<? get-val r)) ⊎-dec ¬? (_↝?_ _≟⊤_ _≟Interval_ l r )
+...          | yes p = yes (dependency-implies-ordering {proof = fromWitness p})
+...          | no ¬p = no lem
+  where
+  lem : (x : l ↝⇒<< r) → ⊥
+  lem (dependency-implies-ordering {proof = p}) = contradiction (toWitness p) ¬p
+
+
+data _↝⇔<<_ : Rel Runnable 0ℓ where
+  bidierctional-dependency-implies-ordering : {l r : Runnable} → {proof : True ((l ↝⇒<<? r) ×-dec (r ↝⇒<<? l))} → l ↝⇔<< r
+
+_↝⇔<<?_ : Decidable {A = Runnable} _↝⇔<<_
+l ↝⇔<<? r with ((l ↝⇒<<? r) ×-dec (r ↝⇒<<? l))
+...          | yes p = yes (bidierctional-dependency-implies-ordering {proof = fromWitness p})
+...          | no ¬p = no lem
+  where
+  lem : (x : l ↝⇔<< r) → ⊥
+  lem (bidierctional-dependency-implies-ordering {proof = p}) = contradiction (toWitness p) ¬p
 
 record Schedule : Set where
+  constructor s[_]s
   field
     schedule : AcyclicGraph ⊤ Interval
-    {no-interval-intersection} : True (NoneIntersect? (Data.List.map AcyclicGraphNode.value (all-nodes {_≟E_ = _≟⊤_} {_≟N_ = _≟Interval_} schedule)))
+    {no-interval-intersection} : True (NoneIntersect? (map get-val (all-nodes {_≟E_ = _≟⊤_} {_≟N_ = _≟Interval_} schedule)))
+    {forall-dependencies-imply-ordering} : True (allPairs? _↝⇔<<?_ (all-nodes {_≟E_ = _≟⊤_} {_≟N_ = _≟Interval_} schedule))
+
+schedule⇒no-interval-intersection : (s : Schedule) → NoneIntersect (map get-val (all-nodes {_≟E_ = _≟⊤_} {_≟N_ = _≟Interval_} (Schedule.schedule s)))
+schedule⇒no-interval-intersection s = toWitness (Schedule.no-interval-intersection s)
+
+schedule⇒forall-dependencies-imply-ordering : (s : Schedule) → AllPairs _↝⇔<<_ (all-nodes {_≟E_ = _≟⊤_} {_≟N_ = _≟Interval_} (Schedule.schedule s))
+schedule⇒forall-dependencies-imply-ordering s = toWitness (Schedule.forall-dependencies-imply-ordering s)
+
+r0 : Runnable
+r0 = n[ [ 7 ▹ 3 ] , [] ]n
+
+r1 : Runnable
+r1 = n[ [ 0 ▹ 4 ] , ((tt , r0) ∷ []) ]n
+
+r2 : Runnable
+r2 = n[ [ 6 ▹ 2 ] , (tt , r0) ∷ [] ]n
+
+r3 : Runnable
+r3 = n[ [ 11 ▹ 2 ] , (tt , r0) ∷ [] ]n
+
+g0 = g[ r1 ]g
+s0 = s[ g0 ]s
+
+-- g1 = g[ r2 ]g
+-- s1 = s[ g1 ]s -- doesn't compile: interval overlap!
+
+--g2 = g[ r3 ]g
+--s2 = s[ g2 ]s -- doesn't compile: dependencies out of order!
+

--- a/project/scheduling/Schedule.agda
+++ b/project/scheduling/Schedule.agda
@@ -1,6 +1,4 @@
 module Schedule where
-open import Data.Nat
-import Data.Nat.Properties
 open import Relation.Binary.PropositionalEquality
 open ≡-Reasoning
 open import Data.Bool using (Bool ; true ; false ; if_then_else_ ; _∨_ ; _∧_)
@@ -20,23 +18,23 @@ open import Relation.Nullary.Sum
 open import Data.Empty
 open import Data.Product using (_×_)
 open import Interval
+open import Pair
 open import AcyclicGraph
 open import Agda.Builtin.Unit
+open import DecidableEquality
 
+open DecEq {{...}}
 
 Runnable = AcyclicGraphNode ⊤ Interval
 
-_≟⊤_ : Decidable {A = ⊤} _≡_
-tt ≟⊤ tt = yes refl
-
 data _↝⇒<<_ : Rel Runnable 0ℓ where
-  dependency-implies-ordering : {l r : Runnable} → {proof : True (((_↝?_ _≟⊤_ _≟Interval_ l r ) ×-dec (get-val l <<? get-val r)) ⊎-dec ¬? (_↝?_ _≟⊤_ _≟Interval_ l r ))} → l ↝⇒<< r
+  dependency-implies-ordering : {l r : Runnable} → {proof : True (((l ↝? r) ×-dec (get-val l <<? get-val r)) ⊎-dec ¬? (l ↝? r))} → l ↝⇒<< r
 
 ↝⇒<<⇒p : {l r : Runnable} → l ↝⇒<< r → ((l ↝ r) × (get-val l << get-val r) ⊎ (¬ l ↝ r))
 ↝⇒<<⇒p (dependency-implies-ordering {proof = p}) = toWitness p
 
 _↝⇒<<?_ : Decidable {A = Runnable} _↝⇒<<_
-l ↝⇒<<? r with  ((_↝?_ _≟⊤_ _≟Interval_ l r ) ×-dec (get-val l <<? get-val r)) ⊎-dec ¬? (_↝?_ _≟⊤_ _≟Interval_ l r )
+l ↝⇒<<? r with  ((l ↝? r) ×-dec (get-val l <<? get-val r)) ⊎-dec ¬? (l ↝? r)
 ...          | yes p = yes (dependency-implies-ordering {proof = fromWitness p})
 ...          | no ¬p = no lem
   where
@@ -59,13 +57,13 @@ record Schedule : Set where
   constructor s[_]s
   field
     schedule : AcyclicGraph ⊤ Interval
-    {no-interval-intersection} : True (NoneIntersect? (map get-val (all-nodes {_≟E_ = _≟⊤_} {_≟N_ = _≟Interval_} schedule)))
-    {forall-dependencies-imply-ordering} : True (allPairs? _↝⇔<<?_ (all-nodes {_≟E_ = _≟⊤_} {_≟N_ = _≟Interval_} schedule))
+    {no-interval-intersection} : True (NoneIntersect? (map get-val (all-nodes schedule)))
+    {forall-dependencies-imply-ordering} : True (allPairs? _↝⇔<<?_ (all-nodes schedule))
 
-schedule⇒no-interval-intersection : (s : Schedule) → NoneIntersect (map get-val (all-nodes {_≟E_ = _≟⊤_} {_≟N_ = _≟Interval_} (Schedule.schedule s)))
+schedule⇒no-interval-intersection : (s : Schedule) → NoneIntersect (map get-val (all-nodes (Schedule.schedule s)))
 schedule⇒no-interval-intersection s = toWitness (Schedule.no-interval-intersection s)
 
-schedule⇒forall-dependencies-imply-ordering : (s : Schedule) → AllPairs _↝⇔<<_ (all-nodes {_≟E_ = _≟⊤_} {_≟N_ = _≟Interval_} (Schedule.schedule s))
+schedule⇒forall-dependencies-imply-ordering : (s : Schedule) → AllPairs _↝⇔<<_ (all-nodes (Schedule.schedule s))
 schedule⇒forall-dependencies-imply-ordering s = toWitness (Schedule.forall-dependencies-imply-ordering s)
 
 r0 : Runnable

--- a/project/scheduling/Schedule.agda
+++ b/project/scheduling/Schedule.agda
@@ -25,15 +25,16 @@ open import DecidableEquality
 
 open DecEq {{...}}
 
-Runnable = AcyclicGraphNode ⊤ Interval
+Task = AcyclicGraphNode ⊤ Interval
+TaskGraph = AcyclicGraph ⊤ Interval
 
-data _↝⇒<<_ : Rel Runnable 0ℓ where
-  dependency-implies-ordering : {l r : Runnable} → {proof : True (((l ↝? r) ×-dec (get-val l <<? get-val r)) ⊎-dec ¬? (l ↝? r))} → l ↝⇒<< r
+data _↝⇒<<_ : Rel Task 0ℓ where
+  dependency-implies-ordering : {l r : Task} → {proof : True (((l ↝? r) ×-dec (get-val l <<? get-val r)) ⊎-dec ¬? (l ↝? r))} → l ↝⇒<< r
 
-↝⇒<<⇒p : {l r : Runnable} → l ↝⇒<< r → ((l ↝ r) × (get-val l << get-val r) ⊎ (¬ l ↝ r))
+↝⇒<<⇒p : {l r : Task} → l ↝⇒<< r → ((l ↝ r) × (get-val l << get-val r) ⊎ (¬ l ↝ r))
 ↝⇒<<⇒p (dependency-implies-ordering {proof = p}) = toWitness p
 
-_↝⇒<<?_ : Decidable {A = Runnable} _↝⇒<<_
+_↝⇒<<?_ : Decidable {A = Task} _↝⇒<<_
 l ↝⇒<<? r with  ((l ↝? r) ×-dec (get-val l <<? get-val r)) ⊎-dec ¬? (l ↝? r)
 ...          | yes p = yes (dependency-implies-ordering {proof = fromWitness p})
 ...          | no ¬p = no lem
@@ -42,10 +43,10 @@ l ↝⇒<<? r with  ((l ↝? r) ×-dec (get-val l <<? get-val r)) ⊎-dec ¬? (l
   lem (dependency-implies-ordering {proof = p}) = contradiction (toWitness p) ¬p
 
 
-data _↝⇔<<_ : Rel Runnable 0ℓ where
-  bidierctional-dependency-implies-ordering : {l r : Runnable} → {proof : True ((l ↝⇒<<? r) ×-dec (r ↝⇒<<? l))} → l ↝⇔<< r
+data _↝⇔<<_ : Rel Task 0ℓ where
+  bidierctional-dependency-implies-ordering : {l r : Task} → {proof : True ((l ↝⇒<<? r) ×-dec (r ↝⇒<<? l))} → l ↝⇔<< r
 
-_↝⇔<<?_ : Decidable {A = Runnable} _↝⇔<<_
+_↝⇔<<?_ : Decidable {A = Task} _↝⇔<<_
 l ↝⇔<<? r with ((l ↝⇒<<? r) ×-dec (r ↝⇒<<? l))
 ...          | yes p = yes (bidierctional-dependency-implies-ordering {proof = fromWitness p})
 ...          | no ¬p = no lem
@@ -66,16 +67,16 @@ schedule⇒no-interval-intersection s = toWitness (Schedule.no-interval-intersec
 schedule⇒forall-dependencies-imply-ordering : (s : Schedule) → AllPairs _↝⇔<<_ (all-nodes (Schedule.schedule s))
 schedule⇒forall-dependencies-imply-ordering s = toWitness (Schedule.forall-dependencies-imply-ordering s)
 
-r0 : Runnable
+r0 : Task
 r0 = n[ [ 7 ▹ 3 ] , [] ]n
 
-r1 : Runnable
+r1 : Task
 r1 = n[ [ 0 ▹ 4 ] , ((tt , r0) ∷ []) ]n
 
-r2 : Runnable
+r2 : Task
 r2 = n[ [ 6 ▹ 2 ] , (tt , r0) ∷ [] ]n
 
-r3 : Runnable
+r3 : Task
 r3 = n[ [ 11 ▹ 2 ] , (tt , r0) ∷ [] ]n
 
 g0 = g[ r1 ]g

--- a/sandbox/sever/RecursiveDecidableEquality.agda
+++ b/sandbox/sever/RecursiveDecidableEquality.agda
@@ -1,0 +1,66 @@
+module RecursiveDecidableEquality where
+
+open import Data.Nat
+open import Data.Fin using (Fin ; fromℕ)
+open import Relation.Binary.PropositionalEquality
+open ≡-Reasoning
+open import Relation.Nullary
+open import Relation.Nullary.Decidable
+open import Data.List using (List ; [] ; _∷_ ; map ; all ; any ; and ; or; _++_ )
+open import Data.Maybe using (Maybe ; nothing ; just)
+open import Data.List using (List; concat; map; length)
+open import Data.List.Membership.Propositional
+open import Relation.Nullary.Decidable using (True)
+open import Relation.Nullary.Negation
+open import Level
+
+open import Relation.Binary
+open import Data.Empty
+
+open import Data.List.Properties using (≡-dec)
+
+record Dummy : Set where
+  inductive
+  field
+    d : List Dummy
+
+{-
+=-dec-dum : Decidable {A = Dummy} _≡_
+=-dec-dum record { d = d₁ } record { d = d } with ≡-dec =-dec-dum d₁ d
+...                                             | yes p = {!!}
+-}
+
+list-append-eq : {A : Set} → (a0 a1 : A) → (l0 l1 : List A) → a0 ≡ a1 → l0 ≡ l1 → a0 ∷ l0 ≡ a1 ∷ l1
+list-append-eq {A} a0 a1 l0 l1 x x₁ = begin
+                                        a0 ∷ l0 ≡⟨ cong (_∷_ a0) x₁ ⟩
+                                        a0 ∷ l1 ≡⟨ cong (λ z → z ∷ l1) x ⟩ a1 ∷ l1 ∎
+
+dummy-append-eq : (a0 a1 : Dummy) → (l0 l1 : List Dummy) → a0 ≡ a1 → l0 ≡ l1 → record { d = (a0 ∷ l0) } ≡ record { d = (a1 ∷ l1) }
+dummy-append-eq a0 a1 l0 l1 x x₁ = begin
+                                     record { d = a0 ∷ l0 } ≡⟨ cong (λ z → record { d = a0 ∷ z }) x₁ ⟩
+                                     record { d = a0 ∷ l1 } ≡⟨ cong (λ z → record { d = z ∷ l1 }) x ⟩
+                                     record { d = a1 ∷ l1 } ∎
+
+dummy-list-eq : {a0 a1 : Dummy} → a0 ≡ a1 → Dummy.d a0 ≡ Dummy.d a1
+dummy-list-eq  = cong Dummy.d
+
+dummy-lem : (a0 a1 : Dummy) → (l0 l1 : List Dummy) → a0 ≡ a1 → record { d = l0 } ≡ record { d = l1 } → record { d = (a0 ∷ l0) } ≡ record { d = (a1 ∷ l1) }
+dummy-lem a0 a1 l0 l1 x x₁ with dummy-list-eq x₁
+... | p = dummy-append-eq a0 a1 l0 l1 x p
+
+=-dec-dum : Decidable {A = Dummy} _≡_
+=-dec-dum record { d = [] } record { d = [] } = yes refl
+=-dec-dum record { d = (x ∷ d₁) } record { d = [] } = no (λ ())
+=-dec-dum record { d = [] } record { d = (x ∷ d) } = no (λ ())
+=-dec-dum record { d = (x₁ ∷ d₁) } record { d = (x ∷ d) } with =-dec-dum record { d = d₁ } record { d = d }
+...                                                          | no ¬p = no lem
+  where
+  lem : (x : record { d = x₁ ∷ d₁ } ≡ record { d = x ∷ d }) → ⊥
+  lem refl = ¬p refl
+...                                                          | yes p with =-dec-dum x₁ x
+... | no ¬q = no lem
+  where
+  lem : (x : record { d = x₁ ∷ d₁ } ≡ record { d = x ∷ d }) → ⊥
+  lem refl = ¬q refl
+... | yes q = yes (dummy-lem x₁ x d₁ d q p)
+


### PR DESCRIPTION
Finished implementing an object which represents the solution to a schedule packing problem called `Schedule`. It consists of a task graph, which represents the dependencies between different schedulable tasks, and a set of intervals defining the times at which each task has been scheduled to occur. The `Schedule` object enforces two constraints at compile-time:

1. No two intervals within the task graph may intersect.
2. If a runnable has a dependency, its interval must occur after the dependency's interval

I suggest to start reading `Schedule.agda`, and to read this PR at the type level (i.e. just the lines which declare function types) before looking at the implementation. I've tried to use a design pattern which makes it so that all the code reads just like regular math notation at the type level.